### PR TITLE
chore: run it after assets automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-      time: "12:30"
+      time: "12:40"
     commit-message:
       prefix: "chore: workflow"
     labels:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+      time: "12:30"
     commit-message:
       prefix: "chore: workflow"
     labels:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-      time: "12:40"
+      time: "13:00"
     commit-message:
       prefix: "chore: workflow"
     labels:


### PR DESCRIPTION
- Run dependabot after this https://github.com/block-wallet/block-devops/blob/d4b9dfc25a6f25e3f26d9e24db02b0eaf7923a10/manifests/services/repository-notifier/assets.yaml#L11