### PR TITLE
fix: add missing custom nodes from blockwallet

### DIFF
--- a/extra-chain-data.json
+++ b/extra-chain-data.json
@@ -12,6 +12,7 @@
     "isTestnet": true
   },
   "5": {
+    "rpc": ["https://goerli-node.blockwallet.io"],
     "scanApi": "https://api-goerli.etherscan.io",
     "nativeCurrency": {
       "name": "Görli Ether",
@@ -157,6 +158,7 @@
   },
   "246": { "scanApi": "https://explorer.energyweb.org" },
   "250": {
+    "rpc": ["https://fantom-node.blockwallet.io"],
     "scanApi": "https://api.ftmscan.com"
   },
   "256": {


### PR DESCRIPTION
# Description

Added both Fantom and Goerli custom nodes from BlockWallet. This will help the wallet to recognize these nodes as valid ones.

![image](https://user-images.githubusercontent.com/98833290/195183107-f88ad10a-26f4-4ff3-954d-60f4d275a06d.png)
![image](https://user-images.githubusercontent.com/98833290/195183150-d02d2d24-0ef4-4b2c-800e-6044a80c4a23.png)
